### PR TITLE
Set up GitHub Actions CI with separate build and test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,28 +1,42 @@
-name: Build & Test
+name: CI
 
 on:
-  push:
-    branches: [ $default-branch ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ main ]
 
 jobs:
-  build:
-
+  build-apk:
+    name: Build APK
     runs-on: ubuntu-latest
-
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
     steps:
       - uses: actions/checkout@v4
-      - name: set up JDK 17
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'amazon-corretto'
           cache: gradle
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
-      - name: Build with Gradle
-        run: ./gradlew build
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
+
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'amazon-corretto'
+          cache: gradle
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
       - name: Run unit tests
         run: ./gradlew test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'amazon-corretto'
+          distribution: 'corretto'
           cache: gradle
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'amazon-corretto'
+          distribution: 'corretto'
           cache: gradle
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# CLAUDE.md — Arcyto Android Project
+# CLAUDE.md
 
-This file provides guidance for AI assistants working on the Arcyto codebase.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
 
@@ -17,10 +17,11 @@ This is consumed at compile time by `core/data/remote/build.gradle.kts` to gener
 ## Build & Run Commands
 
 ```bash
-./gradlew build           # Full build + tests
-./gradlew test            # Unit tests only
-./gradlew assembleDebug   # Debug APK
-./gradlew assembleRelease # Release APK (minified)
+./gradlew build                        # Full build + tests
+./gradlew test                         # Unit tests only
+./gradlew assembleDebug                # Debug APK
+./gradlew assembleRelease              # Release APK (minified)
+./gradlew :feature:history:impl:test   # Run tests for a single module
 ```
 
 ## Module Structure

--- a/core/data/remote/build.gradle.kts
+++ b/core/data/remote/build.gradle.kts
@@ -11,7 +11,9 @@ val localProperties = Properties().apply {
         load(localPropertiesFile.inputStream())
     }
 }
-val apiKey = localProperties.getProperty("API_KEY") ?: "API KEY Not Found!" // Default if not found
+val apiKey = System.getenv("API_KEY")
+    ?: localProperties.getProperty("API_KEY")
+    ?: "API KEY Not Found!"
 
 android {
     buildFeatures.buildConfig = true


### PR DESCRIPTION
## Summary
- Split CI workflow into two parallel jobs: **Build APK** (`assembleDebug`) and **Unit Tests** (`test`)
- Updated API key resolution to check `System.getenv("API_KEY")` first (GitHub secret), then `local.properties` (local dev), with a fallback placeholder
- Workflow triggers on pull requests targeting `main`

## Test plan
- [ ] Verify both jobs appear and run in parallel in the GitHub Actions UI
- [ ] Confirm local builds still work using `local.properties`
- [ ] Confirm CI builds use the `API_KEY` secret